### PR TITLE
Fix Write and Read memory leaks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # libmpsse
 #
 
+# The make install below requires sudo.
 .PHONY: install
 install: ## Install the libmpsse package with python disabled
 	cd src ; ./configure --disable-python
@@ -9,9 +10,17 @@ install: ## Install the libmpsse package with python disabled
 	cd src ; make install
 	cd src ; make distclean
 
+.PHONY: clean
+clean:  ## Remove temporary files
+	go clean -v || exit
+
 .PHONY: build
 build: install ## Install the libmpsse package and run 'go build'
 	go build
+
+.PHONY: fmt
+fmt:  ## Run goimports on all go files
+	find . -name '*.go' -not -wholename './vendor/*' | while read -r file; do goimports -w "$$file" || exit; done
 
 .PHONY: lint
 lint: ## Lint the Go source code

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,5 @@
 package libmpsse
 
-
 // MpsseError is the error that is returned when an MPSSE failure is
 // detected. The error message it provides is the message retrieved from
 // the ErrorString function.

--- a/mpsse_darwin.go
+++ b/mpsse_darwin.go
@@ -13,7 +13,6 @@ import (
 // #include "mpsse.h"
 import "C"
 
-
 const (
 	// MpsseOK represents the "ok" response from an MPSSE command.
 	MpsseOK = 0
@@ -22,7 +21,6 @@ const (
 	MpsseFail = -1
 )
 
-
 // Mode is an integer that is used to identify the MPSSE operating
 // mode. The values here match the values in the C implementation
 // enum.
@@ -30,12 +28,12 @@ type Mode int
 
 // Supported MPSSE modes.
 const (
-	SPI0 Mode = 1
-	SPI1 Mode = 2
-	SPI2 Mode = 3
-	SPI3 Mode = 4
-	I2C  Mode = 5
-	GPIO Mode = 6
+	SPI0    Mode = 1
+	SPI1    Mode = 2
+	SPI2    Mode = 3
+	SPI3    Mode = 4
+	I2C     Mode = 5
+	GPIO    Mode = 6
 	BITBANG Mode = 7
 )
 
@@ -46,17 +44,17 @@ type Frequency int
 
 // Common clock rates.
 const (
-	OneHundredKHZ   Frequency = 100000
-	FourHundredKHZ  Frequency = 400000
-	OneMHZ          Frequency = 1000000
-	TwoMHZ          Frequency = 2000000
-	FiveMHZ         Frequency = 5000000
-	SixMHZ          Frequency = 6000000
-	TenMHZ          Frequency = 10000000
-	TwelveMHZ       Frequency = 12000000
-	FifteenMHZ      Frequency = 15000000
-	ThirtyMHZ       Frequency = 30000000
-	SixtyMHZ        Frequency = 60000000
+	OneHundredKHZ  Frequency = 100000
+	FourHundredKHZ Frequency = 400000
+	OneMHZ         Frequency = 1000000
+	TwoMHZ         Frequency = 2000000
+	FiveMHZ        Frequency = 5000000
+	SixMHZ         Frequency = 6000000
+	TenMHZ         Frequency = 10000000
+	TwelveMHZ      Frequency = 12000000
+	FifteenMHZ     Frequency = 15000000
+	ThirtyMHZ      Frequency = 30000000
+	SixtyMHZ       Frequency = 60000000
 )
 
 // Endianess defines how data is clocked in and out (MSB/LSB). These values
@@ -112,7 +110,6 @@ const (
 	InterfaceD   = 4
 )
 
-
 // Mpsse is a struct that holds the context information for an MPSSE session.
 // It holds a reference to the C context pointer that is used for all
 // commands.
@@ -122,13 +119,11 @@ type Mpsse struct {
 	lock sync.Mutex
 }
 
-
 // ok is a helper function to check if the response status of an MPSSE command
 // completed successfully.
 func ok(status int) bool {
 	return status == MpsseOK
 }
-
 
 // MPSSE opens and initializes the first FTDI device found.
 //
@@ -148,7 +143,6 @@ func MPSSE(mode Mode, frequency Frequency, endianess Endianess) (*Mpsse, error) 
 	return d, nil
 }
 
-
 // Open opens a device by VID/PID.
 //
 // Since the C version is a wrapper around OpenIndex for index 0, we just pass
@@ -156,7 +150,6 @@ func MPSSE(mode Mode, frequency Frequency, endianess Endianess) (*Mpsse, error) 
 func Open(vid int, pid int, mode Mode, frequency Frequency, endianess Endianess, iface Iface, description *string, serial *string) (*Mpsse, error) {
 	return OpenIndex(vid, pid, mode, frequency, endianess, iface, description, serial, 0)
 }
-
 
 // OpenIndex opens a device by VID/PID/index.
 //
@@ -207,7 +200,6 @@ func OpenIndex(vid int, pid int, mode Mode, frequency Frequency, endianess Endia
 	return d, nil
 }
 
-
 // Close closes the device, deinitializes libftdi, and frees the MPSSE
 // context pointer.
 //
@@ -215,8 +207,8 @@ func OpenIndex(vid int, pid int, mode Mode, frequency Frequency, endianess Endia
 //     void Close(struct mpsse_context *mpsse);
 func (m *Mpsse) Close() {
 	C.Close(m.ctx)
+	m = nil // Force error / panic if a client tries to use a deallocated / closed Mpsse.
 }
-
 
 // ErrorString retrieves the last error string from libftdi.
 //
@@ -225,7 +217,6 @@ func (m *Mpsse) Close() {
 func (m *Mpsse) ErrorString() string {
 	return C.GoString(C.ErrorString(m.ctx))
 }
-
 
 // SetMode sets the appropriate transmit and receive commands based on the
 // requested mode and byte order.
@@ -241,7 +232,6 @@ func (m *Mpsse) SetMode(endianess Endianess) error {
 	return nil
 }
 
-
 // EnableBitmode enables bit-wise data transfers. Must be called after
 // MPSSE() / Open() / OpenIndex().
 //
@@ -250,7 +240,6 @@ func (m *Mpsse) SetMode(endianess Endianess) error {
 func (m *Mpsse) EnableBitmode(tf int) {
 	C.EnableBitmode(m.ctx, C.int(tf))
 }
-
 
 // SetClock sets tha appropriate divisor for the desired clock frequency.
 //
@@ -265,7 +254,6 @@ func (m *Mpsse) SetClock(freq uint32) error {
 	return nil
 }
 
-
 // GetClock gets the currently configured clock rate.
 //
 // It is a wrapper for the mpsse C function:
@@ -273,7 +261,6 @@ func (m *Mpsse) SetClock(freq uint32) error {
 func (m *Mpsse) GetClock() int {
 	return int(C.GetClock(m.ctx))
 }
-
 
 // GetVid returns the vendor ID of the FTDI chip.
 //
@@ -283,7 +270,6 @@ func (m *Mpsse) GetVid() int {
 	return int(C.GetVid(m.ctx))
 }
 
-
 // GetPid returns the product ID of the FTDI chip.
 //
 // It is a wrapper for the mpsse C function:
@@ -292,7 +278,6 @@ func (m *Mpsse) GetPid() int {
 	return int(C.GetPid(m.ctx))
 }
 
-
 // GetDescription returns the description of the FTDI chip, if any.
 //
 // It is a wrapper for the mpsse C function:
@@ -300,7 +285,6 @@ func (m *Mpsse) GetPid() int {
 func (m *Mpsse) GetDescription() string {
 	return C.GoString(C.GetDescription(m.ctx))
 }
-
 
 // SetLoopback enables or disables internal loopback.
 //
@@ -315,7 +299,6 @@ func (m *Mpsse) SetLoopback(enable int) error {
 	return nil
 }
 
-
 // SetCSIdle sets the idle state of the chip select pin. CS idles high
 // by default.
 //
@@ -324,7 +307,6 @@ func (m *Mpsse) SetLoopback(enable int) error {
 func (m *Mpsse) SetCSIdle(idle int) {
 	C.SetCSIdle(m.ctx, C.int(idle))
 }
-
 
 // Start sends the data start condition.
 //
@@ -339,26 +321,25 @@ func (m *Mpsse) Start() error {
 	return nil
 }
 
-
 // Write sends data out via the selected serial protocol.
 //
 // It is a wrapper for the mpsse C function:
 //     int Write(struct mpsse_context *mpsse, char *data, int size);
 func (m *Mpsse) Write(data string) error {
 	dataP := C.CString(data)
-	defer C.free(unsafe.Pointer(dataP))
-
-	// FIXME -- need to check that this works. not clear that len(data) gives
-	// us the size that we want. maybe unsafe.Sizeof will give the int
-	// size we want? but I'm also unsure about that. will need to test.
 	status := int(C.Write(m.ctx, dataP, C.int(len(data))))
+
+	// free whether we succeed or fail.
+	// DANGER: This free used to be called in a defer statement.
+	// The code was called because a trace in the code was emitted,
+	// but the memory was _not_ freed. Suspect a compiler bug.
+	C.free(unsafe.Pointer(dataP))
 
 	if !ok(status) {
 		return &MpsseError{m.ErrorString()}
 	}
 	return nil
 }
-
 
 // Stop sends the data stop condition.
 //
@@ -373,7 +354,6 @@ func (m *Mpsse) Stop() error {
 	return nil
 }
 
-
 // GetAck returns the last received ACK bit.
 //
 // It is a wrapper for the mpsse C function:
@@ -382,7 +362,6 @@ func (m *Mpsse) GetAck() int {
 	return int(C.GetAck(m.ctx))
 }
 
-
 // SetAck sets the transmitted ACK bit.
 //
 // It is a wrapper for the mpsse C function:
@@ -390,7 +369,6 @@ func (m *Mpsse) GetAck() int {
 func (m *Mpsse) SetAck(ack I2CAck) {
 	C.SetAck(m.ctx, C.int(ack))
 }
-
 
 // SendAcks causes libmpsse to send ACKs after each read byte in
 // I2C mode.
@@ -401,7 +379,6 @@ func (m *Mpsse) SendAcks() {
 	C.SendAcks(m.ctx)
 }
 
-
 // SendNacks causes libmpsse to send NACKs after each read byte in
 // I2C mode.
 //
@@ -411,7 +388,6 @@ func (m *Mpsse) SendNacks() {
 	C.SendNacks(m.ctx)
 }
 
-
 // FlushAfterRead enables or disables flushing of the FTDI chip's RX
 // buffers after each read operation. Flushing is disabled by default.
 //
@@ -420,7 +396,6 @@ func (m *Mpsse) SendNacks() {
 func (m *Mpsse) FlushAfterRead(tf int) {
 	C.FlushAfterRead(m.ctx, C.int(tf))
 }
-
 
 // PinHigh sets the specified pin high.
 //
@@ -435,7 +410,6 @@ func (m *Mpsse) PinHigh(pin GPIOPin) error {
 	return nil
 }
 
-
 // PinLow sets the specified pin low.
 //
 // It is a wrapper for the mpsse C function:
@@ -448,7 +422,6 @@ func (m *Mpsse) PinLow(pin GPIOPin) error {
 	}
 	return nil
 }
-
 
 // SetDirection sets ths input/output direction of all pins. For use in
 // BITBANG mode only.
@@ -464,20 +437,17 @@ func (m *Mpsse) SetDirection(direction uint8) error {
 	return nil
 }
 
-
 // WriteBits performs a bit-wise write of up to 8 bits at a time.
 //
 // It is a wrapper for the mpsse C function:
 //     int WriteBits(struct mpsse_context *mpsse, char bits, int size);
 func (m *Mpsse) WriteBits() {}
 
-
 // ReadBits performs a bit-wise read of up to 8 bits.
 //
 // It is a wrapper for the mpsse C function:
 //     char ReadBits(struct mpsse_context *mpsse, int size);
 func (m *Mpsse) ReadBits() {}
-
 
 // WritePins sets the input/output value of all pins. For use in BITBANG
 // mode only.
@@ -493,7 +463,6 @@ func (m *Mpsse) WritePins(data uint8) error {
 	return nil
 }
 
-
 // ReadPins reads the state of the chip's pins. For use in BITBANG mode
 // only.
 //
@@ -503,7 +472,6 @@ func (m *Mpsse) ReadPins() int {
 	return int(C.ReadPins(m.ctx))
 }
 
-
 // PinState checks if a specific pin is high or low. For use in BITBANG
 // mode only.
 //
@@ -512,7 +480,6 @@ func (m *Mpsse) ReadPins() int {
 func (m *Mpsse) PinState(pin, state int) int {
 	return int(C.PinState(m.ctx, C.int(pin), C.int(state)))
 }
-
 
 // Tristate places all I/O pins into a tristate mode.
 //
@@ -527,13 +494,11 @@ func (m *Mpsse) Tristate() error {
 	return nil
 }
 
-
 // Version returns the libmpsse version number.
 //
 // It is a wrapper for the mpsse C function:
 //     char Version(void);
 func Version() {}
-
 
 // Read reads data over the selected serial protocol.
 //
@@ -550,8 +515,14 @@ func (m *Mpsse) Read(size int) string {
 	// given number of times - if a result comes back as 0x00, we do
 	// not treat it as empty, but instead add it to the response string
 	// as the value \x00.
+
+	// Above means that golang is treating "\x00" as an empty C
+	// null terminated string which makes sense. Here this is just
+	// bytes, and we want to keep the \x00 bytes.
 	for i := 0; i < size; i++ {
-		read := C.GoString(C.Read(m.ctx, C.int(1)))
+		charPtr := C.Read(m.ctx, C.int(1))
+		read := C.GoString(charPtr)
+		C.free(unsafe.Pointer(charPtr))
 		if read == "" {
 			resp += "\x00"
 		} else {
@@ -561,7 +532,6 @@ func (m *Mpsse) Read(size int) string {
 	return resp
 }
 
-
 // Transfer reads and writes data over the selected serial protocol
 // (SPI only).
 //
@@ -569,20 +539,17 @@ func (m *Mpsse) Read(size int) string {
 //     char *Transfer(struct mpsse_context *mpsse, char *data, int size);
 func (m *Mpsse) Transfer() {}
 
-
 // FastWrite is a function for performing fast writes in MPSSE.
 //
 // It is a wrapper for the mpsse C function:
 //     int FastWrite(struct mpsse_context *mpsse, char *data, int size);
 func (m *Mpsse) FastWrite() {}
 
-
 // FastRead is a function for performing fast reads in MPSSE.
 //
 // It is a wrapper for the mpsse C function:
 //     int FastRead(struct mpsse_context *mpsse, char *data, int size);
 func (m *Mpsse) FastRead() {}
-
 
 // FastTransfer is a function to perform fast transfers in MPSSE.
 //

--- a/mpsse_linux.go
+++ b/mpsse_linux.go
@@ -13,7 +13,6 @@ import (
 // #include "mpsse.h"
 import "C"
 
-
 const (
 	// MpsseOK represents the "ok" response from an MPSSE command.
 	MpsseOK = 0
@@ -22,7 +21,6 @@ const (
 	MpsseFail = -1
 )
 
-
 // Mode is an integer that is used to identify the MPSSE operating
 // mode. The values here match the values in the C implementation
 // enum.
@@ -30,12 +28,12 @@ type Mode int
 
 // Supported MPSSE modes.
 const (
-	SPI0 Mode = 1
-	SPI1 Mode = 2
-	SPI2 Mode = 3
-	SPI3 Mode = 4
-	I2C  Mode = 5
-	GPIO Mode = 6
+	SPI0    Mode = 1
+	SPI1    Mode = 2
+	SPI2    Mode = 3
+	SPI3    Mode = 4
+	I2C     Mode = 5
+	GPIO    Mode = 6
 	BITBANG Mode = 7
 )
 
@@ -46,17 +44,17 @@ type Frequency int
 
 // Common clock rates.
 const (
-	OneHundredKHZ   Frequency = 100000
-	FourHundredKHZ  Frequency = 400000
-	OneMHZ          Frequency = 1000000
-	TwoMHZ          Frequency = 2000000
-	FiveMHZ         Frequency = 5000000
-	SixMHZ          Frequency = 6000000
-	TenMHZ          Frequency = 10000000
-	TwelveMHZ       Frequency = 12000000
-	FifteenMHZ      Frequency = 15000000
-	ThirtyMHZ       Frequency = 30000000
-	SixtyMHZ        Frequency = 60000000
+	OneHundredKHZ  Frequency = 100000
+	FourHundredKHZ Frequency = 400000
+	OneMHZ         Frequency = 1000000
+	TwoMHZ         Frequency = 2000000
+	FiveMHZ        Frequency = 5000000
+	SixMHZ         Frequency = 6000000
+	TenMHZ         Frequency = 10000000
+	TwelveMHZ      Frequency = 12000000
+	FifteenMHZ     Frequency = 15000000
+	ThirtyMHZ      Frequency = 30000000
+	SixtyMHZ       Frequency = 60000000
 )
 
 // Endianess defines how data is clocked in and out (MSB/LSB). These values
@@ -112,7 +110,6 @@ const (
 	InterfaceD   = 4
 )
 
-
 // Mpsse is a struct that holds the context information for an MPSSE session.
 // It holds a reference to the C context pointer that is used for all
 // commands.
@@ -122,13 +119,11 @@ type Mpsse struct {
 	lock sync.Mutex
 }
 
-
 // ok is a helper function to check if the response status of an MPSSE command
 // completed successfully.
 func ok(status int) bool {
 	return status == MpsseOK
 }
-
 
 // MPSSE opens and initializes the first FTDI device found.
 //
@@ -148,7 +143,6 @@ func MPSSE(mode Mode, frequency Frequency, endianess Endianess) (*Mpsse, error) 
 	return d, nil
 }
 
-
 // Open opens a device by VID/PID.
 //
 // Since the C version is a wrapper around OpenIndex for index 0, we just pass
@@ -156,7 +150,6 @@ func MPSSE(mode Mode, frequency Frequency, endianess Endianess) (*Mpsse, error) 
 func Open(vid int, pid int, mode Mode, frequency Frequency, endianess Endianess, iface Iface, description *string, serial *string) (*Mpsse, error) {
 	return OpenIndex(vid, pid, mode, frequency, endianess, iface, description, serial, 0)
 }
-
 
 // OpenIndex opens a device by VID/PID/index.
 //
@@ -207,7 +200,6 @@ func OpenIndex(vid int, pid int, mode Mode, frequency Frequency, endianess Endia
 	return d, nil
 }
 
-
 // Close closes the device, deinitializes libftdi, and frees the MPSSE
 // context pointer.
 //
@@ -215,8 +207,8 @@ func OpenIndex(vid int, pid int, mode Mode, frequency Frequency, endianess Endia
 //     void Close(struct mpsse_context *mpsse);
 func (m *Mpsse) Close() {
 	C.Close(m.ctx)
+	m = nil // Force panic / error if a client tries to use a deallocated / closed Mpsse.
 }
-
 
 // ErrorString retrieves the last error string from libftdi.
 //
@@ -225,7 +217,6 @@ func (m *Mpsse) Close() {
 func (m *Mpsse) ErrorString() string {
 	return C.GoString(C.ErrorString(m.ctx))
 }
-
 
 // SetMode sets the appropriate transmit and receive commands based on the
 // requested mode and byte order.
@@ -241,7 +232,6 @@ func (m *Mpsse) SetMode(endianess Endianess) error {
 	return nil
 }
 
-
 // EnableBitmode enables bit-wise data transfers. Must be called after
 // MPSSE() / Open() / OpenIndex().
 //
@@ -250,7 +240,6 @@ func (m *Mpsse) SetMode(endianess Endianess) error {
 func (m *Mpsse) EnableBitmode(tf int) {
 	C.EnableBitmode(m.ctx, C.int(tf))
 }
-
 
 // SetClock sets tha appropriate divisor for the desired clock frequency.
 //
@@ -265,7 +254,6 @@ func (m *Mpsse) SetClock(freq uint32) error {
 	return nil
 }
 
-
 // GetClock gets the currently configured clock rate.
 //
 // It is a wrapper for the mpsse C function:
@@ -273,7 +261,6 @@ func (m *Mpsse) SetClock(freq uint32) error {
 func (m *Mpsse) GetClock() int {
 	return int(C.GetClock(m.ctx))
 }
-
 
 // GetVid returns the vendor ID of the FTDI chip.
 //
@@ -283,7 +270,6 @@ func (m *Mpsse) GetVid() int {
 	return int(C.GetVid(m.ctx))
 }
 
-
 // GetPid returns the product ID of the FTDI chip.
 //
 // It is a wrapper for the mpsse C function:
@@ -292,7 +278,6 @@ func (m *Mpsse) GetPid() int {
 	return int(C.GetPid(m.ctx))
 }
 
-
 // GetDescription returns the description of the FTDI chip, if any.
 //
 // It is a wrapper for the mpsse C function:
@@ -300,7 +285,6 @@ func (m *Mpsse) GetPid() int {
 func (m *Mpsse) GetDescription() string {
 	return C.GoString(C.GetDescription(m.ctx))
 }
-
 
 // SetLoopback enables or disables internal loopback.
 //
@@ -315,7 +299,6 @@ func (m *Mpsse) SetLoopback(enable int) error {
 	return nil
 }
 
-
 // SetCSIdle sets the idle state of the chip select pin. CS idles high
 // by default.
 //
@@ -324,7 +307,6 @@ func (m *Mpsse) SetLoopback(enable int) error {
 func (m *Mpsse) SetCSIdle(idle int) {
 	C.SetCSIdle(m.ctx, C.int(idle))
 }
-
 
 // Start sends the data start condition.
 //
@@ -339,26 +321,26 @@ func (m *Mpsse) Start() error {
 	return nil
 }
 
-
 // Write sends data out via the selected serial protocol.
 //
 // It is a wrapper for the mpsse C function:
 //     int Write(struct mpsse_context *mpsse, char *data, int size);
 func (m *Mpsse) Write(data string) error {
-	dataP := C.CString(data)
-	defer C.free(unsafe.Pointer(dataP))
 
-	// FIXME -- need to check that this works. not clear that len(data) gives
-	// us the size that we want. maybe unsafe.Sizeof will give the int
-	// size we want? but I'm also unsure about that. will need to test.
+	dataP := C.CString(data)
 	status := int(C.Write(m.ctx, dataP, C.int(len(data))))
+
+	// free whether we succeed or fail.
+	// DANGER: This free used to be called in a defer statement.
+	// The code was called because a trace in the code was emitted,
+	// but the memory was _not_ freed. Suspect a compiler bug.
+	C.free(unsafe.Pointer(dataP))
 
 	if !ok(status) {
 		return &MpsseError{m.ErrorString()}
 	}
 	return nil
 }
-
 
 // Stop sends the data stop condition.
 //
@@ -373,7 +355,6 @@ func (m *Mpsse) Stop() error {
 	return nil
 }
 
-
 // GetAck returns the last received ACK bit.
 //
 // It is a wrapper for the mpsse C function:
@@ -382,7 +363,6 @@ func (m *Mpsse) GetAck() int {
 	return int(C.GetAck(m.ctx))
 }
 
-
 // SetAck sets the transmitted ACK bit.
 //
 // It is a wrapper for the mpsse C function:
@@ -390,7 +370,6 @@ func (m *Mpsse) GetAck() int {
 func (m *Mpsse) SetAck(ack I2CAck) {
 	C.SetAck(m.ctx, C.int(ack))
 }
-
 
 // SendAcks causes libmpsse to send ACKs after each read byte in
 // I2C mode.
@@ -401,7 +380,6 @@ func (m *Mpsse) SendAcks() {
 	C.SendAcks(m.ctx)
 }
 
-
 // SendNacks causes libmpsse to send NACKs after each read byte in
 // I2C mode.
 //
@@ -411,7 +389,6 @@ func (m *Mpsse) SendNacks() {
 	C.SendNacks(m.ctx)
 }
 
-
 // FlushAfterRead enables or disables flushing of the FTDI chip's RX
 // buffers after each read operation. Flushing is disabled by default.
 //
@@ -420,7 +397,6 @@ func (m *Mpsse) SendNacks() {
 func (m *Mpsse) FlushAfterRead(tf int) {
 	C.FlushAfterRead(m.ctx, C.int(tf))
 }
-
 
 // PinHigh sets the specified pin high.
 //
@@ -435,7 +411,6 @@ func (m *Mpsse) PinHigh(pin GPIOPin) error {
 	return nil
 }
 
-
 // PinLow sets the specified pin low.
 //
 // It is a wrapper for the mpsse C function:
@@ -448,7 +423,6 @@ func (m *Mpsse) PinLow(pin GPIOPin) error {
 	}
 	return nil
 }
-
 
 // SetDirection sets ths input/output direction of all pins. For use in
 // BITBANG mode only.
@@ -464,20 +438,17 @@ func (m *Mpsse) SetDirection(direction uint8) error {
 	return nil
 }
 
-
 // WriteBits performs a bit-wise write of up to 8 bits at a time.
 //
 // It is a wrapper for the mpsse C function:
 //     int WriteBits(struct mpsse_context *mpsse, char bits, int size);
 func (m *Mpsse) WriteBits() {}
 
-
 // ReadBits performs a bit-wise read of up to 8 bits.
 //
 // It is a wrapper for the mpsse C function:
 //     char ReadBits(struct mpsse_context *mpsse, int size);
 func (m *Mpsse) ReadBits() {}
-
 
 // WritePins sets the input/output value of all pins. For use in BITBANG
 // mode only.
@@ -493,7 +464,6 @@ func (m *Mpsse) WritePins(data uint8) error {
 	return nil
 }
 
-
 // ReadPins reads the state of the chip's pins. For use in BITBANG mode
 // only.
 //
@@ -503,7 +473,6 @@ func (m *Mpsse) ReadPins() int {
 	return int(C.ReadPins(m.ctx))
 }
 
-
 // PinState checks if a specific pin is high or low. For use in BITBANG
 // mode only.
 //
@@ -512,7 +481,6 @@ func (m *Mpsse) ReadPins() int {
 func (m *Mpsse) PinState(pin, state int) int {
 	return int(C.PinState(m.ctx, C.int(pin), C.int(state)))
 }
-
 
 // Tristate places all I/O pins into a tristate mode.
 //
@@ -527,13 +495,11 @@ func (m *Mpsse) Tristate() error {
 	return nil
 }
 
-
 // Version returns the libmpsse version number.
 //
 // It is a wrapper for the mpsse C function:
 //     char Version(void);
 func Version() {}
-
 
 // Read reads data over the selected serial protocol.
 //
@@ -550,8 +516,14 @@ func (m *Mpsse) Read(size int) string {
 	// given number of times - if a result comes back as 0x00, we do
 	// not treat it as empty, but instead add it to the response string
 	// as the value \x00.
+
+	// Above means that golang is treating "\x00" as an empty C
+	// null terminated string which makes sense. Here this is just
+	// bytes, and we want to keep the \x00 bytes.
 	for i := 0; i < size; i++ {
-		read := C.GoString(C.Read(m.ctx, C.int(1)))
+		charPtr := C.Read(m.ctx, C.int(1))
+		read := C.GoString(charPtr)
+		C.free(unsafe.Pointer(charPtr))
 		if read == "" {
 			resp += "\x00"
 		} else {
@@ -561,7 +533,6 @@ func (m *Mpsse) Read(size int) string {
 	return resp
 }
 
-
 // Transfer reads and writes data over the selected serial protocol
 // (SPI only).
 //
@@ -569,20 +540,17 @@ func (m *Mpsse) Read(size int) string {
 //     char *Transfer(struct mpsse_context *mpsse, char *data, int size);
 func (m *Mpsse) Transfer() {}
 
-
 // FastWrite is a function for performing fast writes in MPSSE.
 //
 // It is a wrapper for the mpsse C function:
 //     int FastWrite(struct mpsse_context *mpsse, char *data, int size);
 func (m *Mpsse) FastWrite() {}
 
-
 // FastRead is a function for performing fast reads in MPSSE.
 //
 // It is a wrapper for the mpsse C function:
 //     int FastRead(struct mpsse_context *mpsse, char *data, int size);
 func (m *Mpsse) FastRead() {}
-
 
 // FastTransfer is a function to perform fast transfers in MPSSE.
 //


### PR DESCRIPTION
This is still in testing for maybe an hour and a half, but the intent is to merge this.

Summary:
- This should fix the read and write memory leaks in the i2c plugin: https://github.com/vapor-ware/synse-i2c-plugin/issues/24

Detail:
- The main leak is the Write leak that very much looks like a compiler bug. This code emitted the trace that free happened, but pprof on the heap still showed the leak. https://github.com/vapor-ware/libmpsse/blob/3e71ede865353d5180f9f80d0a37fa549bd325da/mpsse_linux.go#L353-L355
- The read leak was just a simple leak which is fine.